### PR TITLE
Make Step parameter editor widget dynamically resize

### DIFF
--- a/openhcs/pyqt_gui/widgets/step_parameter_editor.py
+++ b/openhcs/pyqt_gui/widgets/step_parameter_editor.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
-    QScrollArea, QFrame
+    QScrollArea, QFrame, QSizePolicy
 )
 from PyQt6.QtCore import Qt, pyqtSignal
 
@@ -25,7 +25,7 @@ from openhcs.pyqt_gui.shared.color_scheme import PyQt6ColorScheme
 logger = logging.getLogger(__name__)
 
 
-class StepParameterEditorWidget(QScrollArea):
+class StepParameterEditorWidget(QWidget):
     """
     Step parameter editor using dynamic form generation.
     
@@ -55,7 +55,7 @@ class StepParameterEditorWidget(QScrollArea):
         parameters = {}
         parameter_types = {}
         param_defaults = {}
-
+        
         for name, info in param_info.items():
             # All AbstractStep parameters are relevant for editing
             # ParameterFormManager will automatically route lazy dataclass parameters to LazyDataclassEditor
@@ -184,23 +184,56 @@ class StepParameterEditorWidget(QScrollArea):
 
 
     def setup_ui(self):
-        """Setup the user interface."""
-        self.setWidgetResizable(True)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        
-        # Main content widget
-        content_widget = QWidget()
-        layout = QVBoxLayout(content_widget)
-        layout.setContentsMargins(10, 10, 10, 10)
-        layout.setSpacing(15)
-        
-        # Header
+        """Setup the user interface (matches FunctionListEditorWidget structure)."""
+        # Main layout directly on self (like FunctionListEditorWidget)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        # Header with controls (like FunctionListEditorWidget)
+        header_layout = QHBoxLayout()
+
+        # Header label
         header_label = QLabel("Step Parameters")
         header_label.setStyleSheet(f"color: {self.color_scheme.to_hex(self.color_scheme.text_accent)}; font-weight: bold; font-size: 14px;")
-        layout.addWidget(header_label)
-        
-        # Parameter form (using shared form manager)
+        header_layout.addWidget(header_label)
+
+        header_layout.addStretch()
+
+        # Action buttons in header (preserving functionality)
+        load_btn = QPushButton("Load .step")
+        load_btn.setMaximumWidth(100)
+        load_btn.setStyleSheet(self._get_button_style())
+        load_btn.clicked.connect(self.load_step_settings)
+        header_layout.addWidget(load_btn)
+
+        save_btn = QPushButton("Save .step As")
+        save_btn.setMaximumWidth(120)
+        save_btn.setStyleSheet(self._get_button_style())
+        save_btn.clicked.connect(self.save_step_settings)
+        header_layout.addWidget(save_btn)
+
+        layout.addLayout(header_layout)
+
+        # Scrollable parameter form (like FunctionListEditorWidget)
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.scroll_area.setStyleSheet(f"""
+            QScrollArea {{
+                background-color: {self.color_scheme.to_hex(self.color_scheme.panel_bg)};
+                border: 1px solid {self.color_scheme.to_hex(self.color_scheme.border_color)};
+                border-radius: 4px;
+            }}
+        """)
+
+        # Parameter form container (like FunctionListEditorWidget)
+        self.parameter_container = QWidget()
+        container_layout = QVBoxLayout(self.parameter_container)
+        container_layout.setContentsMargins(10, 10, 10, 10)
+        container_layout.setSpacing(15)
+
+       # Parameter form (using shared form manager)
         # ParameterFormManager automatically routes lazy dataclass parameters to LazyDataclassEditor
         form_frame = QFrame()
         form_frame.setFrameStyle(QFrame.Shape.Box)
@@ -213,34 +246,20 @@ class StepParameterEditorWidget(QScrollArea):
             }}
         """)
 
+        # Set size policy to allow form frame to expand
+        form_frame.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
         form_layout = QVBoxLayout(form_frame)
 
         # Add parameter form manager
         form_layout.addWidget(self.form_manager)
 
-        layout.addWidget(form_frame)
-        
-        # Action buttons (mirrors Textual TUI)
-        button_layout = QHBoxLayout()
-        
-        load_btn = QPushButton("Load .step")
-        load_btn.setMaximumWidth(100)
-        load_btn.setStyleSheet(self._get_button_style())
-        load_btn.clicked.connect(self.load_step_settings)
-        button_layout.addWidget(load_btn)
-        
-        save_btn = QPushButton("Save .step As")
-        save_btn.setMaximumWidth(120)
-        save_btn.setStyleSheet(self._get_button_style())
-        save_btn.clicked.connect(self.save_step_settings)
-        button_layout.addWidget(save_btn)
-        
-        button_layout.addStretch()
-        layout.addLayout(button_layout)
-        
-        layout.addStretch()
-        
-        self.setWidget(content_widget)
+        # Add form frame with stretch factor to make it expand
+        container_layout.addWidget(form_frame, 1)  # stretch factor = 1
+
+        # Set container in scroll area and add to main layout (like FunctionListEditorWidget)
+        self.scroll_area.setWidget(self.parameter_container)
+        layout.addWidget(self.scroll_area)
     
     def _get_button_style(self) -> str:
         """Get consistent button styling."""


### PR DESCRIPTION
# Step Settings Tab Resize Fix

## Problem
The **Step Settings** tab in the OpenHCS PyQt6 GUI did not resize vertically with the window, leaving a fixed-size content area. This caused wasted space and inconsistent behavior compared to the Function Pattern tab.

## Root Cause
`StepParameterEditorWidget` inherited from `QScrollArea` without a main layout on `self`, so parent resize events were ignored. In contrast, `FunctionListEditorWidget` used a `QWidget` with a main layout and scroll area as a child, which resized correctly.

## Solution
- Changed `StepParameterEditorWidget` to inherit from `QWidget`  
- Added main layout on `self` to handle resizing  
- Made scroll area a child widget  
- Moved Load/Save buttons to header  
- Added size policies and stretch factors for content expansion  

**File Modified:** `openhcs/pyqt_gui/widgets/step_parameter_editor.py`

## Testing
- Resize window in `DualEditorWindow` → Step Settings tab now expands/contracts  
- Load/Save buttons work as expected  
- Parameter editing and scrolling function normally  
- Behavior matches Function Pattern tab

## Result
- ✅ Tab resizes correctly  
- ✅ Functionality preserved  
- ✅ No regressions
