### PR TITLE
Menu bar cleanup

### DIFF
--- a/openhcs/constants/constants.py
+++ b/openhcs/constants/constants.py
@@ -65,7 +65,8 @@ def __getattr__(name):
 
 
 
-
+#Documentation URL
+DOCUMENTATION_URL = "https://openhcs.readthedocs.io/en/latest/"
 
 
 class OrchestratorState(Enum):


### PR DESCRIPTION
### Changes
- Reorganized main menu for better usability
- Removed unusable buttons to reduce user confusion
- Removed non-functional `self.dock_widgets` references
- Removed redundant "help" menu and provided a direct link to documentation

Closes issue #18 
This PR streamlines the menu interface by focusing on useful functionality.