### PR TITLE
Add automatic .pipeline extension when saving pipeline file

### DIFF
--- a/openhcs/pyqt_gui/widgets/pipeline_editor.py
+++ b/openhcs/pyqt_gui/widgets/pipeline_editor.py
@@ -807,6 +807,8 @@ class PipelineEditorWidget(QWidget):
         Args:
             file_path: Path to save pipeline
         """
+        if not str(file_path).lower().endswith('.pipeline'):
+            file_path = Path(str(file_path) + '.pipeline')
         try:
             import dill as pickle
             with open(file_path, 'wb') as f:


### PR DESCRIPTION
### Problem
Pipeline save functionality requires users to remember to add the `.pipeline` extension, leading to inconsistent file naming and potential user confusion.

### Solution
Added code to automatically append the `.pipeline` extension to file paths when saving pipeline files if not already present:

```python
if not str(file_path).lower().endswith('.pipeline'):
    file_path = Path(str(file_path) + '.pipeline')
```
This change ensures all saved pipelines have the proper extension, making it simpler for users.