### PR TITLE
Add `openhcs` console script for easy GUI launch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
 ]
 
 [project.scripts]
-openhcs-gui = "openhcs.pyqt_gui.__main__:main"
+openhcs = "openhcs.pyqt_gui.__main__:main"
 
 [project.optional-dependencies]
 # Development dependencies (CPU-only testing)


### PR DESCRIPTION
### Changes
Added console script entry point in `pyproject.toml` to allow users to launch the GUI with a simple command after pip install:

```toml
[project.scripts]
openhcs = "openhcs.pyqt_gui.__main__:main"
```
Usage
After installing with pip install openhcs[all], users can now run: "openhcs", instead of: "python -m openhcs.pyqt_gui".
This provides a more convenient and intuitive way to launch the OpenHCS GUI.